### PR TITLE
Fix vinga not being executable by the worker user

### DIFF
--- a/scripts/jutge-install-vinga
+++ b/scripts/jutge-install-vinga
@@ -18,7 +18,7 @@ sudo wget -O /usr/local/bin/jutge-vinga https://github.com/jutge-org/jutge-vinga
 sudo wget -O /usr/local/bin/jutge-somhi https://raw.githubusercontent.com/jutge-org/jutge-toolkit/master/scripts/jutge-somhi
 
 sudo chown root:root /usr/local/bin/jutge-vinga
-sudo chmod 700 /usr/local/bin/jutge-vinga
+sudo chmod 755 /usr/local/bin/jutge-vinga
 sudo chmod +s /usr/local/bin/jutge-vinga
 
 sudo chown root:root /usr/local/bin/jutge-somhi


### PR DESCRIPTION
In the process of adding `jutge-somhi`, `jutge-vinga`'s setup process was changed as follows:

`chmod +x /usr/local/bin/jutge-vinga` changed into `chmod 700 /usr/local/bin/jutge-vinga`. Unfortunately, this implies only the root user may execute vinga. Other users (such as worker), may not execute vinga at this point in time.

Testing this is fairly simple:

```sh
#!/bin/sh

touch a b
chmod 700 a
chmod +x b
ls -lh
```

This pull request *reverts* this change, introduced by [3f3698a](https://github.com/jutge-org/jutge-toolkit/commit/2754591d3a8e6814dee56febea9a608040c6ee2c), keeping the expected behaviour by the standard (and possibly other) driver. 